### PR TITLE
Harden update endpoint and upload handling

### DIFF
--- a/inc/classes/manage.class.php
+++ b/inc/classes/manage.class.php
@@ -105,9 +105,10 @@ class Manage {
 						$tc_db->Execute("UPDATE `" .KU_DBPREFIX. "staff` SET salt = '" .$salt. "' WHERE username = " .$tc_db->qstr($_POST['username']));
 						$newpass = md5($_POST['password'] . $salt);
 						$tc_db->Execute("UPDATE `" .KU_DBPREFIX. "staff` SET password = '" .$newpass. "' WHERE username = " .$tc_db->qstr($_POST['username']));
+						session_regenerate_id(true);
 						$_SESSION['manageusername'] = $_POST['username'];
 						$_SESSION['managepassword'] = $newpass;
-            			$_SESSION['token'] = md5($_SESSION['manageusername'] . $_SESSION['managepassword'] . rand(0,100));
+							$_SESSION['token'] = ku_random_token();
 						$this->SetModerationCookies();
 						$tc_db->Execute("DELETE FROM `" . KU_DBPREFIX . "loginattempts` WHERE `ip` < '" . KU_REMOTE_ADDR . "'");
 						$action = 'posting_rates';
@@ -119,9 +120,10 @@ class Manage {
 					}
 				} else {
 					if (md5($_POST['password'] . $results[0]['salt']) == $results[0]['password']) {
+						session_regenerate_id(true);
 						$_SESSION['manageusername'] = $_POST['username'];
 						$_SESSION['managepassword'] = md5($_POST['password'] . $results[0]['salt']);
-            $_SESSION['token'] = md5($_SESSION['manageusername'] . $_SESSION['managepassword'] . rand(0,100));
+							$_SESSION['token'] = ku_random_token();
 						$this->SetModerationCookies();
 						$action = 'posting_rates';
 						management_addlogentry(_gettext('Logged in'), 1);
@@ -159,7 +161,7 @@ class Manage {
 	}
 
   function CheckToken($posttoken) {
-    if ($posttoken != $_SESSION['token']) {
+    if (!isset($_SESSION['token']) || !is_string($posttoken) || !hash_equals($_SESSION['token'], $posttoken)) {
       // Something is strange
       session_destroy();
       exitWithErrorPage(_gettext('Invalid Token'));
@@ -196,7 +198,7 @@ class Manage {
 		if ($this->CurrentUserIsAdministrator()) {
 			return true;
 		} else {
-			$results = $tc_db->GetAll("SELECT HIGH_PRIORITY `type` FROM `" . KU_DBPREFIX . "staff` WHERE `username` = '" . $_SESSION['manageusername'] . "' AND `password` = '" . $_SESSION['managepassword'] . "' LIMIT 1");
+			$results = $tc_db->GetAll("SELECT HIGH_PRIORITY `type` FROM `" . KU_DBPREFIX . "staff` WHERE `username` = " . $tc_db->qstr($_SESSION['manageusername']) . " AND `password` = " . $tc_db->qstr($_SESSION['managepassword']) . " LIMIT 1");
 			foreach ($results as $line) {
 				if ($line['type'] != 2 && $line['type'] != 3) {
 					exitWithErrorPage(_gettext('That page is for moderators and administrators only.'));
@@ -253,7 +255,7 @@ class Manage {
 	function CurrentUserIsModeratorOfBoard($board, $username) {
 		global $tc_db, $tpl_page;
 
-		$results = $tc_db->GetAll("SELECT HIGH_PRIORITY `type`, `boards` FROM `" . KU_DBPREFIX . "staff` WHERE `username` = '" . $username . "' LIMIT 1");
+		$results = $tc_db->GetAll("SELECT HIGH_PRIORITY `type`, `boards` FROM `" . KU_DBPREFIX . "staff` WHERE `username` = " . $tc_db->qstr($username) . " LIMIT 1");
 		if (count($results) > 0) {
 			foreach ($results as $line) {
 				if ($line['boards'] == 'allboards') {
@@ -1042,7 +1044,7 @@ class Manage {
 		if ($dir != '' && $desc != '') {
 			$results = $tc_db->GetAll("SELECT HIGH_PRIORITY * FROM `" . KU_DBPREFIX . "boards` WHERE `name` = " . $tc_db->qstr($dir) . "");
 			if (count($results) == 0) {
-				$moderating = array_filter(explode('|', $tc_db->GetOne("SELECT HIGH_PRIORITY `boards` FROM `" . KU_DBPREFIX . "staff` WHERE `username` = '" . $_SESSION['manageusername'] . "'")));
+				$moderating = array_filter(explode('|', $tc_db->GetOne("SELECT HIGH_PRIORITY `boards` FROM `" . KU_DBPREFIX . "staff` WHERE `username` = " . $tc_db->qstr($_SESSION['manageusername']) . "")));
 				$existingboards = $tc_db->GetAll("SELECT HIGH_PRIORITY `name` from `" . KU_DBPREFIX . "boards`");
 				foreach($existingboards as &$exb) {
 					$xba[] = $exb['name'];
@@ -1052,7 +1054,7 @@ class Manage {
 				if (mkdir(KU_BOARDSDIR . $dir, 0777) && mkdir(KU_BOARDSDIR . $dir . '/res', 0777) && mkdir(KU_BOARDSDIR . $dir . '/src', 0777) && mkdir(KU_BOARDSDIR . $dir . '/thumb', 0777) && mkdir(KU_BOARDSDIR . $dir . '/tmp', 0777) && mkdir(KU_BOARDSDIR . $dir . '/tmp/thumb', 0777)) {
 					/* Add mod rights */
 					$moderating[] = $dir;
-					$tc_db->Execute("UPDATE `" . KU_DBPREFIX . "staff` SET `boards` = " . $tc_db->qstr(implode('|',$moderating)) . " WHERE `username` = '" . $_SESSION['manageusername'] . "'");
+					$tc_db->Execute("UPDATE `" . KU_DBPREFIX . "staff` SET `boards` = " . $tc_db->qstr(implode('|',$moderating)) . " WHERE `username` = " . $tc_db->qstr($_SESSION['manageusername']) . "");
 					file_put_contents(KU_BOARDSDIR . $dir . '/.htaccess', 'DirectoryIndex '. 'board.html' . '');
 					if(KU_OFFLOAD)
 					{
@@ -3625,7 +3627,7 @@ class Manage {
 		$bannedhashes = 0;
 		if (isset($_POST['banhashtime']) && $_POST['banhashtime'] !== '' && ($_POST['hash'] !== '' || isset($_POST['multibanhashes'])) && $_POST['banhashtime'] >= 0) {
 			if (isset($_POST['multibanhashes']))
-				$banhashes = unserialize($_POST['multibanhashes']);
+				$banhashes = ku_safe_unserialize_array($_POST['multibanhashes']);
 			else
 				$banhashes = Array($_POST['hash']);
 			foreach ($banhashes as $banhash){
@@ -3698,7 +3700,7 @@ class Manage {
 					if ($ban_appealat > 0) $ban_appealat += (time() + KU_ADDTIME);
 				}
 				if (isset($_POST['multiban']))
-					$ban_ips = unserialize($_POST['multiban']);
+					$ban_ips = ku_safe_unserialize_array($_POST['multiban']);
 				else
 					$ban_ips = Array($ban_ip);
 				$i = 0;
@@ -3719,7 +3721,7 @@ class Manage {
 							if (isset($ban_post_id))
 								$postids = Array($ban_post_id);
 							else
-								$postids = unserialize($_POST['quickmultibanpostid']);
+								$postids = ku_safe_unserialize_array($_POST['quickmultibanpostid']);
 							$results = $tc_db->GetAll("SELECT HIGH_PRIORITY `parentid`, `message` FROM `".KU_DBPREFIX."posts` WHERE `boardid` = " . $tc_db->qstr($ban_board_id) . " AND `id` = ".$tc_db->qstr($postids[$i])." LIMIT 1");
 
 							foreach($results AS $line) {
@@ -4113,7 +4115,7 @@ class Manage {
 
 				$i = 0;
 				if (isset($_POST['multiban']))
-					$ips = unserialize($_POST['multiban']);
+					$ips = ku_safe_unserialize_array($_POST['multiban']);
 				else
 					$ips = Array($_POST['ip']);
 				foreach  ($ips as $ip) {
@@ -4182,7 +4184,7 @@ class Manage {
 			if ($_POST['clear'] != '') {
 				$clear_decrypted = md5_decrypt($_POST['clear'], KU_RANDOMSEED);
 				if ($clear_decrypted != '') {
-					$clear_unserialized = unserialize($clear_decrypted);
+					$clear_unserialized = ku_safe_unserialize_array($clear_decrypted);
 
 					foreach ($clear_unserialized as $clear_sql) {
 						$tc_db->Execute($clear_sql);
@@ -4246,7 +4248,7 @@ class Manage {
 			if ($_POST['clear'] != '') {
 				$clear_decrypted = md5_decrypt($_POST['clear'], KU_RANDOMSEED);
 				if ($clear_decrypted != '') {
-					$clear_unserialized = unserialize($clear_decrypted);
+					$clear_unserialized = ku_safe_unserialize_array($clear_decrypted);
 
 					foreach ($clear_unserialized as $clear_sql) {
 						$tc_db->Execute($clear_sql);
@@ -4340,7 +4342,7 @@ class Manage {
 		global $tc_db, $tpl_page;
 
 		$staff_boardsmoderated = array();
-		$results = $tc_db->GetAll("SELECT HIGH_PRIORITY `boards` FROM `" . KU_DBPREFIX . "staff` WHERE `username` = '" . $username . "' LIMIT 1");
+		$results = $tc_db->GetAll("SELECT HIGH_PRIORITY `boards` FROM `" . KU_DBPREFIX . "staff` WHERE `username` = " . $tc_db->qstr($username) . " LIMIT 1");
 		if ($this->CurrentUserIsAdministrator() || $results[0][0] == 'allboards') {
 			$resultsboard = $tc_db->GetAll("SELECT HIGH_PRIORITY `id`, `name` FROM `" . KU_DBPREFIX . "boards` ORDER BY `name` ASC");
 			foreach ($resultsboard as $lineboard) {

--- a/inc/classes/upload.class.php
+++ b/inc/classes/upload.class.php
@@ -58,6 +58,9 @@ class Upload {
 		$dir1 = KU_BOARDSDIR . $board_class->board['name'] . '/tmp';
 		$dir2 = KU_BOARDSDIR . $board_class->board['name'] . '/tmp/thumb';
 		$dir3 = KU_BOARDSDIR . 'tmp/xhrupload';
+		$files1 = array();
+		$files2 = array();
+		$files3 = array();
 		if (is_dir($dir1))
 		{
 			$files1 = scandir($dir1);
@@ -182,15 +185,21 @@ class Upload {
 					{
 						if ($_POST['drop_file_name'] != '')
 						{
-							if(!file_exists($_POST['drop_file_name']))
+							$drop_file_name = $_POST['drop_file_name'];
+							if(!file_exists($drop_file_name))
 							{
 								return 'Время хранения файла вышло. Перезалей его ещё раз.';
 							}
+							if(!ku_path_in_dir($drop_file_name, $dir3))
+							{
+								return 'Недопустимый путь временного файла.';
+							}
+							$drop_file_name = realpath($drop_file_name);
 							$file = array();
-							$file['size'] = filesize($_POST['drop_file_name']);
+							$file['size'] = filesize($drop_file_name);
 							$file['error'] = UPLOAD_ERR_OK;
-							$file['name'] = basename($_POST['drop_file_name']);
-							$file['tmp_name'] = $_POST['drop_file_name'];
+							$file['name'] = basename($drop_file_name);
+							$file['tmp_name'] = $drop_file_name;
 							$imagefile_name = $file['name'];
 						}
 					}
@@ -202,18 +211,29 @@ class Upload {
 							{
 								$file = array();
 								$file['name'] = substr($_POST['embedlink'], 2);
+								if(!ku_safe_attachment_filename($file['name']))
+								{
+									return 'Недопустимое имя файла.';
+								}
 								if($temporary)
 								{
-									$file['tmp_name'] = KU_BOARDSDIR . $board_class->board['name'] . '/src/' . $file['name'];
+									$reuse_base_dir = KU_BOARDSDIR . $board_class->board['name'] . '/src';
+									$file['tmp_name'] = $reuse_base_dir . '/' . $file['name'];
 								}
 								else
 								{
-									$file['tmp_name'] = KU_BOARDSDIR . $board_class->board['name'] . '/tmp/saved' . $file['name'];
-									if(!file_exists($file['tmp_name']))
-									{
-										return 'Время хранения файла вышло. Перезалей его ещё раз.';
-									}
+									$reuse_base_dir = KU_BOARDSDIR . $board_class->board['name'] . '/tmp';
+									$file['tmp_name'] = $reuse_base_dir . '/saved' . $file['name'];
 								}
+								if(!file_exists($file['tmp_name']))
+								{
+									return 'Время хранения файла вышло. Перезалей его ещё раз.';
+								}
+								if(!ku_path_in_dir($file['tmp_name'], $reuse_base_dir))
+								{
+									return 'Недопустимый путь файла.';
+								}
+								$file['tmp_name'] = realpath($file['tmp_name']);
 								$file['size'] = filesize($file['tmp_name']);
 								$file['error'] = UPLOAD_ERR_OK;
 								$imagefile_name = $file['name'];

--- a/inc/func/custom.php
+++ b/inc/func/custom.php
@@ -93,7 +93,7 @@ function getUserMode() // Returns 0 = user, 1 = admin, 2 = mod, 4 = skipcaptcha,
 		return 0;
 	}
 
-	$results = $tc_db->GetAll("SELECT HIGH_PRIORITY `type` FROM `" . KU_DBPREFIX . "staff` WHERE `username` = '" . $_SESSION['manageusername'] . "' AND `password` = '" . $_SESSION['managepassword'] . "' LIMIT 1");
+	$results = $tc_db->GetAll("SELECT HIGH_PRIORITY `type` FROM `" . KU_DBPREFIX . "staff` WHERE `username` = " . $tc_db->qstr($_SESSION['manageusername']) . " AND `password` = " . $tc_db->qstr($_SESSION['managepassword']) . " LIMIT 1");
 	if (count($results) < 1) return -1;
 	return $results[0]['type'];
 }

--- a/inc/func/misc.php
+++ b/inc/func/misc.php
@@ -22,75 +22,281 @@ function md5_image($file)
 	return $image_md5;
 }
 
+function ku_is_public_ip($ip)
+{
+	return filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== false;
+}
+
+function ku_remote_url_ips($host)
+{
+	if (!is_string($host) || $host === '') {
+		return false;
+	}
+
+	$host = trim($host, "[] \t\n\r\0\x0B");
+	if (filter_var($host, FILTER_VALIDATE_IP)) {
+		return array($host);
+	}
+
+	if (!preg_match('/^[A-Za-z0-9.-]+$/', $host)) {
+		return false;
+	}
+
+	$ips = array();
+	$records = @dns_get_record($host, DNS_A + DNS_AAAA);
+	if (is_array($records)) {
+		foreach ($records as $record) {
+			if (isset($record['ip'])) {
+				$ips[] = $record['ip'];
+			}
+			if (isset($record['ipv6'])) {
+				$ips[] = $record['ipv6'];
+			}
+		}
+	}
+
+	if (empty($ips)) {
+		$ipv4 = @gethostbynamel($host);
+		if (is_array($ipv4)) {
+			$ips = array_merge($ips, $ipv4);
+		}
+	}
+
+	$ips = array_values(array_unique($ips));
+	return empty($ips) ? false : $ips;
+}
+
+function ku_validate_remote_url($url)
+{
+	if (!is_string($url) || strlen($url) > 2048) {
+		return array(false, 'Invalid URL');
+	}
+
+	$parts = parse_url($url);
+	if ($parts === false || empty($parts['scheme']) || empty($parts['host'])) {
+		return array(false, 'Invalid URL');
+	}
+
+	$scheme = strtolower($parts['scheme']);
+	if ($scheme !== 'http' && $scheme !== 'https') {
+		return array(false, 'Only http and https URLs are allowed');
+	}
+
+	if (isset($parts['user']) || isset($parts['pass'])) {
+		return array(false, 'URLs with credentials are not allowed');
+	}
+
+	$ips = ku_remote_url_ips($parts['host']);
+	if ($ips === false) {
+		return array(false, 'Unable to resolve host');
+	}
+
+	foreach ($ips as $ip) {
+		if (!ku_is_public_ip($ip)) {
+			return array(false, 'Remote URL resolves to a private or reserved address');
+		}
+	}
+
+	return array(true, '');
+}
+
+function ku_build_redirect_url($base_url, $location)
+{
+	if (!is_string($location) || $location === '') {
+		return false;
+	}
+
+	if (parse_url($location, PHP_URL_SCHEME) !== null) {
+		return $location;
+	}
+
+	$base = parse_url($base_url);
+	if ($base === false || empty($base['scheme']) || empty($base['host'])) {
+		return false;
+	}
+
+	$authority = $base['scheme'] . '://' . $base['host'];
+	if (isset($base['port'])) {
+		$authority .= ':' . $base['port'];
+	}
+
+	if (substr($location, 0, 2) === '//') {
+		return $base['scheme'] . ':' . $location;
+	}
+
+	if (substr($location, 0, 1) === '/') {
+		return $authority . $location;
+	}
+
+	$path = isset($base['path']) ? $base['path'] : '/';
+	$dir = preg_replace('#/[^/]*$#', '/', $path);
+	return $authority . $dir . $location;
+}
+
+function ku_curl_apply_common_options($ch)
+{
+	curl_setopt($ch, CURLOPT_HEADER, true);
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+	curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
+	curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+	curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+	curl_setopt($ch, CURLOPT_USERAGENT, 'Kurisaba remote upload');
+
+	$protocols = 0;
+	if (defined('CURLPROTO_HTTP')) {
+		$protocols |= CURLPROTO_HTTP;
+	}
+	if (defined('CURLPROTO_HTTPS')) {
+		$protocols |= CURLPROTO_HTTPS;
+	}
+	if ($protocols !== 0) {
+		curl_setopt($ch, CURLOPT_PROTOCOLS, $protocols);
+		if (defined('CURLOPT_REDIR_PROTOCOLS')) {
+			curl_setopt($ch, CURLOPT_REDIR_PROTOCOLS, $protocols);
+		}
+	}
+}
+
 function file_get_contents_remote($url, $checksize)
 {
-    $success = false;
-	$ch = curl_init($url);
-	if(($err = curl_error($ch)) != '') return 'curl_init(): '. $err;
-	curl_setopt($ch, CURLOPT_HEADER, false);
-	if(($err = curl_error($ch)) != '') return 'curl_setopt(CURLOPT_HEADER): '. $err;
-	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-	if(($err = curl_error($ch)) != '') return 'curl_setopt(CURLOPT_RETURNTRANSFER): '. $err;
-	curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-	curl_setopt($ch, CURLOPT_MAXREDIRS, 4);
-	if (KU_CURL_PROXY == "interface") {
-		curl_setopt($ch, CURLOPT_INTERFACE, /*"venet0:0"*/ /*"tunb"*/ KU_CURL_INTERFACE );
-		if(($err = curl_error($ch)) != '') return 'curl_setopt(CURLOPT_INTERFACE): '. $err;
-	} else if (KU_CURL_PROXY == "vpnbook") {
-		curl_setopt($ch, CURLOPT_COOKIEJAR, "");
-		if(($err = curl_error($ch)) != '') return 'curl_setopt(CURLOPT_COOKIEJAR): '. $err;
-		curl_setopt($ch, CURLOPT_URL, "https://frproxy.vpnbook.com/includes/process.php?action=update");
-		if(($err = curl_error($ch)) != '') return 'curl_setopt(CURLOPT_URL): '. $err;
-		curl_setopt($ch, CURLOPT_POST, 1);
-		curl_setopt($ch, CURLOPT_POSTFIELDS, array('u' => $url, 'webproxylocation' => 'random'));
-		if(($err = curl_error($ch)) != '') return 'curl_setopt(CURLOPT_POSTFIELDS): '. $err;
-	} else if ((KU_CURL_PROXY != "none")) {
-		return "curl: insufficient KU_CURL_PROXY";
+	$redirects = 0;
+	$current_url = $url;
+
+	while ($redirects <= 4) {
+		$url_check = ku_validate_remote_url($current_url);
+		if ($url_check[0] === false) {
+			return array(false, $url_check[1]);
+		}
+
+		$ch = curl_init($current_url);
+		if (($err = curl_error($ch)) != '') {
+			return array(false, 'curl_init(): ' . $err);
+		}
+		ku_curl_apply_common_options($ch);
+
+		if ($checksize) {
+			curl_setopt($ch, CURLOPT_NOBODY, true);
+		}
+
+		if (KU_CURL_PROXY == "interface") {
+			curl_setopt($ch, CURLOPT_INTERFACE, KU_CURL_INTERFACE);
+			if (($err = curl_error($ch)) != '') {
+				return array(false, 'curl_setopt(CURLOPT_INTERFACE): ' . $err);
+			}
+		} else if (KU_CURL_PROXY == "vpnbook") {
+			curl_setopt($ch, CURLOPT_COOKIEJAR, "");
+			if (($err = curl_error($ch)) != '') {
+				return array(false, 'curl_setopt(CURLOPT_COOKIEJAR): ' . $err);
+			}
+			curl_setopt($ch, CURLOPT_URL, "https://frproxy.vpnbook.com/includes/process.php?action=update");
+			if (($err = curl_error($ch)) != '') {
+				return array(false, 'curl_setopt(CURLOPT_URL): ' . $err);
+			}
+			curl_setopt($ch, CURLOPT_POST, 1);
+			curl_setopt($ch, CURLOPT_POSTFIELDS, array('u' => $current_url, 'webproxylocation' => 'random'));
+			if (($err = curl_error($ch)) != '') {
+				return array(false, 'curl_setopt(CURLOPT_POSTFIELDS): ' . $err);
+			}
+		} else if (KU_CURL_PROXY != "none") {
+			return array(false, "curl: insufficient KU_CURL_PROXY");
+		}
+
+		$ret = curl_exec($ch);
+		if (($err = curl_error($ch)) != '') {
+			curl_close($ch);
+			return array(false, 'curl_exec(): ' . $err);
+		}
+
+		$status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+		$header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+		curl_close($ch);
+
+		$headers = substr($ret, 0, $header_size);
+		$body = substr($ret, $header_size);
+
+		if ($status >= 300 && $status <= 308) {
+			if (!preg_match('/^Location:\s*(.+)$/im', $headers, $matches)) {
+				return array(false, 'Redirect response without Location header');
+			}
+			$next_url = ku_build_redirect_url($current_url, trim($matches[1]));
+			if ($next_url === false) {
+				return array(false, 'Invalid redirect URL');
+			}
+			$current_url = $next_url;
+			$redirects++;
+			continue;
+		}
+
+		if ($status < 200 || $status >= 300) {
+			return array(false, 'Request failed with status code ' . $status);
+		}
+
+		if ($checksize) {
+			if (preg_match('/^Content-Length:\s*(\d+)$/im', $headers, $matches)) {
+				return array(true, (int) $matches[1]);
+			}
+			return array(false, 'Unable to determine content length when checking file size');
+		}
+
+		return array(true, $body);
 	}
-    // Set up timeouts (see issue #101)
-    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
-    curl_setopt($ch, CURLOPT_TIMEOUT, 30);
-    if($checksize)
-    {
-        curl_setopt($ch, CURLOPT_HEADER, 1);
-    }
-	$ret = curl_exec($ch);
-	if(($err = curl_error($ch)) != '') return 'curl_exec(): '. $err;
-	$status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-	curl_close($ch);
-    if($checksize)
-    {
-        // See https://stackoverflow.com/questions/2602612/remote-file-size-without-downloading-file
-        if($ret)
-        {
-            $content_length = "unknown";
-            if($status == 200 || ($status > 300 && $status <= 308))
-            {
-                if(preg_match("/Content-Length: (\d+)/i", $ret, $matches))
-                {
-                    $success = true;
-                    $ret = (int)$matches[1];
-                }
-                else
-                {
-                    $ret = 'curl_exec(): Unable to determine content length when checking file size';
-                }
-            }
-            else
-            {
-                $ret = 'curl_exec(): Request failed with status code ' . $status . ' when checking file size';
-            }
-        }
-        else
-        {
-            $ret = 'curl_exec(): Empty response when checking file size';
-        }
-    }
-    else
-    {
-        $success = true;
-    }
-	return [$success, $ret];
+
+	return array(false, 'Too many redirects');
+}
+
+function ku_normalize_base_dir($dir)
+{
+	$real = realpath($dir);
+	if ($real === false) {
+		return false;
+	}
+	return rtrim(str_replace('\\', '/', $real), '/') . '/';
+}
+
+function ku_path_in_dir($path, $dir)
+{
+	$base = ku_normalize_base_dir($dir);
+	$real = realpath($path);
+	if ($base === false || $real === false) {
+		return false;
+	}
+	$real = str_replace('\\', '/', $real);
+	return strpos($real, $base) === 0;
+}
+
+function ku_safe_attachment_filename($filename)
+{
+	return is_string($filename)
+		&& $filename !== ''
+		&& basename($filename) === $filename
+		&& strpos($filename, '..') === false
+		&& preg_match('/^[A-Za-z0-9._-]+$/', $filename);
+}
+
+function ku_safe_unserialize_array($payload)
+{
+	if (!is_string($payload) || $payload === '') {
+		return array();
+	}
+
+	if (PHP_VERSION_ID >= 70000) {
+		$data = @unserialize($payload, array('allowed_classes' => false));
+	} else {
+		$data = @unserialize($payload);
+	}
+
+	return is_array($data) ? $data : array();
+}
+
+function ku_random_token($bytes = 32)
+{
+	if (function_exists('random_bytes')) {
+		return bin2hex(random_bytes($bytes));
+	}
+	if (function_exists('openssl_random_pseudo_bytes')) {
+		return bin2hex(openssl_random_pseudo_bytes($bytes));
+	}
+	return md5(uniqid(mt_rand(), true));
 }
 
 function changeLocale($newlocale) {
@@ -264,7 +470,7 @@ function management_addlogentry($entry, $category = 0, $forceusername = '') {
 	$username = ($forceusername == '') ? $_SESSION['manageusername'] : $forceusername;
 
 	if ($entry != '') {
-		$tc_db->Execute("INSERT INTO `" . KU_DBPREFIX . "modlog` ( `entry` , `user` , `category` , `timestamp` ) VALUES ( " . $tc_db->qstr($entry) . " , '" . $username . "' , " . $tc_db->qstr($category) . " , '" . (time() + KU_ADDTIME) . "' )");
+		$tc_db->Execute("INSERT INTO `" . KU_DBPREFIX . "modlog` ( `entry` , `user` , `category` , `timestamp` ) VALUES ( " . $tc_db->qstr($entry) . " , " . $tc_db->qstr($username) . " , " . $tc_db->qstr($category) . " , '" . (time() + KU_ADDTIME) . "' )");
 	}
 }
 

--- a/update_engine.php
+++ b/update_engine.php
@@ -1,1 +1,23 @@
-<?php header('Content-Type: text/plain'); system('git pull origin master 2>&1'); ?>
+<?php
+session_start(['cookie_samesite' => 'Strict']);
+require 'config.php';
+require KU_ROOTDIR . 'inc/functions.php';
+require KU_ROOTDIR . 'inc/classes/manage.class.php';
+
+header('Content-Type: text/plain; charset=utf-8');
+
+$manage_class = new Manage();
+$manage_class->ValidateSession();
+$manage_class->AdministratorsOnly();
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+	http_response_code(405);
+	echo "Use POST with a valid management token to update the engine.\n";
+	exit;
+}
+
+$manage_class->CheckToken(isset($_POST['token']) ? $_POST['token'] : '');
+
+$command = 'git -C ' . escapeshellarg(KU_ROOTDIR) . ' pull --ff-only origin master 2>&1';
+passthru($command, $exit_code);
+exit($exit_code);


### PR DESCRIPTION
# Security hardening for update endpoint, remote uploads, local upload reuse, sessions, and unsafe deserialization

## Summary

This patch closes several real attack surfaces found during a source review:

- Protects `update_engine.php` so it is no longer an unauthenticated web-triggered `git pull`.
- Hardens remote URL uploads against SSRF by allowing only HTTP(S), rejecting private/reserved IP ranges, disabling automatic redirects, and revalidating manual redirects.
- Restricts drag/drop and saved-file reuse paths to the expected upload directories and safe basenames.
- Replaces unsafe `unserialize()` on request-derived data with an array-only wrapper that disables class hydration on PHP 7+.
- Escapes staff username/password values in previously unsafe SQL string concatenations.
- Uses a stronger management CSRF token and `hash_equals()` token comparison.
- Regenerates the session ID after successful staff login.

## Risk notes

The highest-risk issues were the public update endpoint and SSRF-capable remote uploads. The SQL/session issues are harder to trigger directly from anonymous traffic, but they are still injection sinks and should be removed while touching the security surface.